### PR TITLE
Bugfix: fix bug in editing scores

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,6 +149,9 @@ public class ParserUtil {
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
+        if (uniqueTagList.contains(new Tag(tagName, "assessment"))) {
+            return uniqueTagList.getTag(tagName, "assessment");
+        }
         return uniqueTagList.getTag(trimmedTag, tagCategory);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -149,8 +149,8 @@ public class ParserUtil {
         if (!Tag.isValidTagName(trimmedTag)) {
             throw new ParseException(Tag.MESSAGE_CONSTRAINTS);
         }
-        if (uniqueTagList.contains(new Tag(tagName, "assessment"))) {
-            return uniqueTagList.getTag(tagName, "assessment");
+        if (uniqueTagList.contains(new Tag(trimmedTag, "assessment"))) {
+            return uniqueTagList.getTag(trimmedTag, "assessment");
         }
         return uniqueTagList.getTag(trimmedTag, tagCategory);
     }


### PR DESCRIPTION
## Bug
When doing `edit 1 sc/interview`, if there are multiple tag categories having tags with the name `interview`, it would display an error saying multiple tag categories exist. In the case of a regular `edit 1 t/interview`, we were able to specify the tag category to decide which of the duplicate tags to return but in the case of `edit 1 sc/interview` used to add score to a specific tag associated to a person, this is not possible due to the way score is implemented and hence becomes a bug. 

## Remedy
To address this bug, a check condition was implemented in the `ParserUtil.parseTag` method. This method, responsible for returning a tag, now checks if the tag used in `edit 1 sc/interview` is present in the `uniqueTagList` with the category `assessment`. If the tag is found in the assessment category, we ignore interview tags in other categories and directly return the tag in the `assessment` category. This resolution allows us to bypass the "multiple tag categories exist..." exception by selecting a specific tag and resolves the "tag must be of the assessment category" exception by ensuring that the chosen tag belongs to the `assessment` category.

