### PR TITLE
Bugfix: add and edit using tags that haven't been created

### DIFF
--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -99,7 +99,9 @@ public class UniqueTagList {
                     return tag;
                 }
             }
-            throw new ParseException("Tag category does not exist!");
+            Tag tag = new Tag(tagName, tagCategory);
+            add(tag);
+            return tag;
         } else if (foundTag.isPresent()) {
             // tag category not specified
             long occurrence = internalList.stream()

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -263,12 +263,6 @@ public class ParserUtilTest {
     }
 
     @Test
-    public void parseTags_collectionWIthInvalidTagsCategorySpecified_throwsParseException() {
-        assertThrows(ParseException.class, () -> ParserUtil.parseTags(Arrays.asList("employment " + VALID_TAG_1, "dept "
-                + VALID_TAG_2)));
-    }
-
-    @Test
     public void parseTagCategories_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseTagCategories(null));
     }

--- a/src/test/java/seedu/address/model/tag/UniqueTagListTest.java
+++ b/src/test/java/seedu/address/model/tag/UniqueTagListTest.java
@@ -4,8 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalTags.TEST_TAG;
-import static seedu.address.testutil.TypicalTags.TEST_TAG_CATEGORY_STRING;
-import static seedu.address.testutil.TypicalTags.TEST_TAG_NAME_STRING;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,24 +52,6 @@ public class UniqueTagListTest {
     @Test
     public void getTag_nullTag_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueTagList.getTag(null, null));
-    }
-
-    @Test
-    public void getTag_tagCategoryDoesNotExist_throwsParseException() {
-        uniqueTagList.add(TEST_TAG);
-        assertThrows(ParseException.class, () -> uniqueTagList.getTag(TEST_TAG_NAME_STRING, "categoryNotInList"));
-    }
-
-    @Test
-    public void getTag_tagNameDoesNotExist_throwsParseException() {
-        uniqueTagList.add(TEST_TAG);
-        assertThrows(ParseException.class, () -> uniqueTagList.getTag("nameNotInList", TEST_TAG_CATEGORY_STRING));
-    }
-
-    @Test
-    public void getTag_tagDoesNotExist_throwsParseException() {
-        System.out.println(uniqueTagList.contains(TEST_TAG));
-        assertThrows(ParseException.class, () -> uniqueTagList.getTag(TEST_TAG_NAME_STRING, TEST_TAG_CATEGORY_STRING));
     }
 
     @Test


### PR DESCRIPTION
Intended functionality: doing `edit 1 t/newcategory test` should add the tag `test` under the category `newcategory` to the person at index 1. Doing `listT` should also display that the new tag has been created. 

Bug: doing `edit 1 t/newcategory test` displays an error message saying that "the tag category does not exist"

Fix: the current `getTag` method in `uniqueTagList` throws an error if it cannot find a tag matching the given name and category in the `uniqueTagList` when it really should be creating a new tag, add it to the tag list and return it so that this tag can be added to the person at the specified index.