### PR TITLE
Bugfix: edit and add with new tag categories

### DIFF
--- a/src/main/java/seedu/address/model/tag/UniqueTagList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueTagList.java
@@ -1,8 +1,12 @@
 package seedu.address.model.tag;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.commands.CreateTagCommand.MESSAGE_FAILURE;
 
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -98,6 +102,10 @@ public class UniqueTagList {
                     return tag;
                 }
             }
+            if (!containsTagCategory(tagCategory)
+                    && countDistinctCategories(internalList) > 5) {
+                throw new ParseException(MESSAGE_FAILURE);
+            }
             Tag tag = new Tag(tagName, tagCategory);
             add(tag);
             return tag;
@@ -119,6 +127,20 @@ public class UniqueTagList {
         Tag uncategorisedTag = new Tag(tagName, "uncategorised");
         this.add(uncategorisedTag); // add uncategorised tag to unique tag list
         return uncategorisedTag;
+    }
+
+    private int countDistinctCategories(List<Tag> tags) {
+        requireNonNull(tags);
+        Set<String> distinctCategories = new HashSet<>();
+
+        for (Tag tag : tags) {
+            String tagCategory = tag.getTagCategory();
+            if (!tagCategory.equals("uncategorised")) {
+                distinctCategories.add(tagCategory);
+            }
+        }
+
+        return distinctCategories.size();
     }
 
     /**


### PR DESCRIPTION
Intended function: doing `edit t/newcategory test` should not work if there are already 6 categories (excluding uncategorised tags) in the tag list.

Bug: it creates a new tag category

Fix: check if there are already 6 categories in the tag list before creating new tag in `getTag` method of `uniqueTagList`